### PR TITLE
Update VIA Conversion to new JSON format

### DIFF
--- a/rubetools/formats/via.py
+++ b/rubetools/formats/via.py
@@ -31,7 +31,13 @@ class VIA(FormatBase):
         else:
             raise FileNotFoundError('Incorrect annotation path.')
 
-        images_metadata = dataset["_via_img_metadata"]
+        """
+         Previous VGG Image Annotator JSON format used the metadata key. 
+         # images_metadata = dataset["_via_img_metadata"]
+         Now it's updated to the image name
+        """
+        images_metadata = dataset
+
         for _, img_data in tqdm(images_metadata.items()):
             img_name = img_data["filename"]
             img_path = os.path.join(self._img_path, img_name)


### PR DESCRIPTION
**Issue :** #3 
VIA Conversion not working for the new JSON Format

**Implementation :**
Remove the old key and add passed the raw dataset as metadata

**Additional Comments :**
Any time can be revert back by uncommeting `images_metadata = dataset["_via_img_metadata"]` and comment out the `images_metadata = dataset`
